### PR TITLE
docs: Update CLAUDE.md to reflect modular project structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,64 +8,76 @@ This is a Rust application that converts Akai AKP (APRG) sampler program files t
 
 ## Architecture
 
-The application is structured around these core components:
+The library is split into focused modules under `src/`:
 
-- **Data Structures** (`src/main.rs:31-108`): Rust structs representing AKP file components
-  - `AkaiProgram`: Top-level container for the entire program
-  - `Keygroup`: Individual keygroup with sample, tuning, filter, envelopes, LFOs, and modulation data
-  - Component structs: `Sample`, `Tune`, `Filter`, `Envelope`, `Lfo`, `Modulation`
+- **Error types** (`src/error.rs`): Custom `AkpError` enum with Display impl, `From<io::Error>`, and `Result<T>` type alias. Variants: `InvalidRiffHeader`, `InvalidAprgSignature`, `UnknownChunkType`, `InvalidChunkSize`, `CorruptedChunk`, `InvalidKeyRange`, `InvalidVelocityRange`, `MissingRequiredChunk`, `InvalidParameterValue`.
 
-- **RIFF Parser** (`src/main.rs:252-408`): Handles binary file parsing
-  - Validates RIFF/APRG headers
-  - Parses nested chunk structures (prg, kgrp, zone, smpl, tune, filt, env, lfo, mods)
-  - Uses `byteorder` crate for little-endian binary data
+- **Data structures** (`src/types.rs`): All pub structs representing AKP file components — `AkaiProgram`, `Keygroup`, `Sample`, `Tune`, `Filter`, `Envelope`, `Lfo`, `Modulation`, `RiffChunkHeader`, `OutputFormat` enum.
 
-- **Multi-Format Generator**: Converts parsed AKP data to multiple output formats
-  - **SFZ Generator** (`src/main.rs:110-212`): Converts to SFZ format with refined parameter scaling
-  - **Decent Sampler Generator**: Converts to Decent Sampler XML with UI controls and effects
-  - Implements exponential envelope curves, logarithmic filter/LFO scaling
-  - Advanced modulation routing with comprehensive source/destination mapping
+- **RIFF parser** (`src/parser.rs`): Binary file parsing with `validate_riff_header()` and `parse_top_level_chunks()` as the public entry points. Parses nested chunk structures (prg, kgrp, zone, smpl, tune, filt, env, lfo, mods). Uses `byteorder` crate for little-endian binary data.
 
-- **Error Handling** (`src/main.rs`): Custom AkpError enum for robust error reporting
-  - InvalidRiffHeader, InvalidAprgSignature, UnknownChunkType
-  - InvalidKeyRange, InvalidVelocityRange, MissingRequiredChunk
-  - Detailed error messages for debugging malformed AKP files
+- **SFZ generator** (`src/sfz.rs`): `impl AkaiProgram { to_sfz_string() }` — converts parsed data to SFZ format with exponential envelope curves, logarithmic filter/LFO scaling, and comprehensive modulation routing.
 
-- **GUI Application** (`gui/src/main.rs`): Modern egui-based interface
-  - Drag & drop file selection with multi-file support
-  - Format selection (SFZ/Decent Sampler) with format descriptions  
-  - Batch processing mode with progress tracking
-  - Real-time conversion results with success/failure reporting
+- **Decent Sampler generator** (`src/dspreset.rs`): `impl AkaiProgram { to_dspreset_string() }` — converts to Decent Sampler XML with UI controls (ADSR, filter, resonance knobs), effects chain, LFO modulators, and MIDI CC routing.
+
+- **Library root** (`src/lib.rs`): Module declarations, re-exports (`AkpError`, `Result`, `AkaiProgram`, `OutputFormat`, `validate_riff_header`, `parse_top_level_chunks`), and `convert_file()` convenience function for GUI integration.
+
+- **CLI binary** (`src/bin/cli.rs`): Command-line interface with single-file conversion, `--format` option, `--batch` directory mode, and progress bars via `indicatif`.
+
+- **GUI application** (`gui/src/main.rs`): Separate crate using `eframe`/`egui`. Drag & drop with hover feedback, format selection using `rusty_samplers::OutputFormat` directly, batch processing, real-time progress tracking, threaded conversion.
+
+## Project Structure
+
+```
+rusty-samplers/
+├── src/
+│   ├── lib.rs               # Library root: module declarations, re-exports, convert_file()
+│   ├── error.rs             # AkpError enum, Display, From, Result alias
+│   ├── types.rs             # All data structs + OutputFormat enum
+│   ├── parser.rs            # RIFF/APRG parsing functions + parser unit tests
+│   ├── sfz.rs               # SFZ generation + SFZ unit tests
+│   ├── dspreset.rs          # Decent Sampler XML generation
+│   └── bin/
+│       └── cli.rs           # CLI binary (rusty-samplers-cli)
+├── gui/                     # GUI application (separate crate)
+│   ├── Cargo.toml           # Depends on eframe, egui, rfd, rusty-samplers
+│   └── src/main.rs          # egui GUI with drag & drop, batch processing
+├── tests/
+│   └── integration_tests.rs # CLI integration tests (5 tests)
+├── examples/
+│   └── test_runner.rs       # Manual test utility for AKP conversion
+├── create_test_akp.py       # Python script to generate test AKP files
+├── CLAUDE.md
+├── README.md
+└── Cargo.toml               # Library + CLI binary, deps: byteorder, indicatif
+```
 
 ## Development Commands
 
-### CLI Application (Note: Currently library-only, no standalone CLI binary)
-The CLI functionality is implemented but main.rs serves as a library. CLI commands from the original design:
-- Convert single AKP file to SFZ format
-- Convert to Decent Sampler format with `--format ds`
-- Batch convert entire directories with `--batch`
+### Build and Check
+- `cargo check`: Check library + CLI for compilation errors (should produce zero warnings)
+- `cargo build`: Build library and CLI binary
+- `cd gui && cargo check`: Check GUI compilation
+- `cd gui && cargo build`: Build GUI binary
 
-### GUI Application (Fully Functional)
-- `cd gui && cargo run`: Launch the GUI interface with full AKP conversion
-- `cargo build`: Build the GUI binary (rusty-samplers-gui)
-- GUI includes: drag & drop, format selection, batch processing, progress tracking
+### Run
+- `cargo run --bin rusty-samplers-cli -- <file.akp>`: Convert single AKP to SFZ
+- `cargo run --bin rusty-samplers-cli -- --format ds <file.akp>`: Convert to Decent Sampler
+- `cargo run --bin rusty-samplers-cli -- --batch <directory>`: Batch convert directory
+- `cd gui && cargo run`: Launch the GUI
 
-### Library Integration
-- `src/lib.rs`: Provides `convert_file()` function for GUI integration
-- `src/main.rs`: Contains core AKP parsing and conversion logic (now public)
-- GUI uses actual conversion logic via library interface
-
-### Development and Testing
-- `cargo build`: Build library and GUI application
-- `cargo check`: Check for compilation errors
-- `cargo test`: Run tests (basic test suite implemented)
+### Test
+- `cargo test`: Run all tests (19 unit + 5 integration = 24 total)
+- `cargo test --lib`: Unit tests only
+- `cargo test --test integration_tests`: Integration tests only
 
 ## Key Implementation Details
 
-- **Envelope Scaling**: Uses exponential curves for attack/decay/release timing (`src/main.rs:146,147,149`)
-- **Filter Cutoff**: Logarithmic scaling from AKP 0-100 to Hz range (`src/main.rs:162`)
-- **LFO Rate**: Logarithmic conversion to Hz frequency (`src/main.rs:173,177`)
-- **Modulation**: Basic linear scaling with placeholder source/destination mappings (`src/main.rs:182-205`)
+- **Envelope Scaling**: Exponential curves for attack/decay/release timing (`src/sfz.rs`)
+- **Filter Cutoff**: Logarithmic scaling from AKP 0-100 to 20Hz–20kHz (`src/sfz.rs`)
+- **LFO Rate**: Logarithmic conversion to 0.1Hz–30Hz (`src/sfz.rs`)
+- **Modulation**: Bipolar normalization with per-destination scale factors, 13 sources × 18 destinations (`src/sfz.rs`)
+- **Volume**: Linear mapping from AKP 0-100 to -60dB–+6dB range
 
 ## File Format Notes
 
@@ -78,7 +90,7 @@ The CLI functionality is implemented but main.rs serves as a library. CLI comman
 
 #### SFZ Format (.sfz)
 - Text-based sampler format with opcodes
-- Forward-slash sample paths (converted from AKP backslashes)  
+- Forward-slash sample paths (converted from AKP backslashes)
 - Advanced parameter mapping for envelopes, filters, and LFOs
 - Modulation routing with source/destination assignments
 
@@ -88,38 +100,3 @@ The CLI functionality is implemented but main.rs serves as a library. CLI comman
 - Effects chain: Lowpass filter + Reverb with parameter bindings
 - LFO modulators with waveform selection and MIDI CC routing
 - Comprehensive sample mapping with velocity/key ranges
-
-## Project Structure
-
-```
-rusty-samplers/
-├── src/
-│   ├── main.rs              # Core conversion logic (public library functions)
-│   ├── lib.rs               # Library interface for GUI integration
-│   └── bin/
-│       └── simple_gui.rs    # Alternative GUI launcher (unused)
-├── gui/                     # Primary GUI application (fully functional)
-│   ├── Cargo.toml          # GUI-specific dependencies + rusty-samplers lib
-│   └── src/main.rs         # Complete GUI with real AKP conversion
-├── tests/                   # Integration tests
-├── CLAUDE.md               # This documentation file  
-├── README.md               # User-facing documentation
-└── Cargo.toml              # Main project configuration
-```
-
-## Current Status (Latest Update)
-
-**✅ Fully Functional**: The project now has a complete working GUI that performs real AKP file conversion.
-
-**Key Achievements**:
-- GUI integrated with actual conversion logic (not simulation)
-- Error handling propagates from core library to GUI interface  
-- File writing system works with real converted content
-- Multi-format support (SFZ + Decent Sampler) fully operational
-- Drag & drop, batch processing, and progress tracking all working
-
-**Architecture Notes**:
-- `src/main.rs` serves as core library with public functions
-- `src/lib.rs` provides clean interface for GUI consumption  
-- `gui/` contains standalone application using the core library
-- Both compilation and runtime integration verified working


### PR DESCRIPTION
## Summary

- Update CLAUDE.md architecture section to describe each module file instead of line ranges in deleted main.rs
- Update project structure tree to match actual file layout
- Update development commands with correct binary name and test counts
- Remove outdated "Current Status" section