### PR TITLE
Fix velocity sensitivity mapping (off by 2x)

### DIFF
--- a/src/dspreset.rs
+++ b/src/dspreset.rs
@@ -59,7 +59,8 @@ impl AkaiProgram {
 
             // Velocity sensitivity (DS range 0.0-1.0, negative not supported)
             if let Some(output) = &self.output {
-                let vel_track = (output.velocity_sensitivity.max(0) as f32 / 50.0).min(1.0);
+                // AKP range (-100..100) → DS range (0.0..1.0), negative unsupported
+                let vel_track = (output.velocity_sensitivity.max(0) as f32 / 100.0).min(1.0);
                 if (vel_track - 1.0).abs() > f32::EPSILON {
                     xml.push_str(&format!(" ampVelTrack=\"{vel_track:.2}\""));
                 }
@@ -230,6 +231,6 @@ mod tests {
         program.keygroups.push(Keygroup::default());
 
         let xml = program.to_dspreset_string();
-        assert!(xml.contains("ampVelTrack=\"0.50\"")); // 25/50 = 0.50
+        assert!(xml.contains("ampVelTrack=\"0.25\"")); // 25/100 = 0.25
     }
 }

--- a/src/sfz.rs
+++ b/src/sfz.rs
@@ -20,7 +20,8 @@ impl AkaiProgram {
                     sfz.push_str(&format!("amplitude={}\n", output.loudness));
                 }
 
-                let vel_track = output.velocity_sensitivity as i32 * 2;
+                // AKP range (-100..100) maps directly to SFZ amp_veltrack (-100..100)
+                let vel_track = output.velocity_sensitivity as i32;
                 if vel_track != 100 {
                     sfz.push_str(&format!("amp_veltrack={vel_track}\n"));
                 }
@@ -238,19 +239,19 @@ mod tests {
         program.keygroups.push(Keygroup::default());
 
         let sfz = program.to_sfz_string();
-        assert!(sfz.contains("amp_veltrack=50")); // 25 * 2 = 50
+        assert!(sfz.contains("amp_veltrack=25")); // direct 1:1 mapping
     }
 
     #[test]
     fn test_sfz_amp_veltrack_omitted_at_default() {
         let mut program = AkaiProgram {
-            output: Some(ProgramOutput { velocity_sensitivity: 50, ..Default::default() }),
+            output: Some(ProgramOutput { velocity_sensitivity: 100, ..Default::default() }),
             ..Default::default()
         };
         program.keygroups.push(Keygroup::default());
 
         let sfz = program.to_sfz_string();
-        assert!(!sfz.contains("amp_veltrack")); // 50 * 2 = 100 = SFZ default, omitted
+        assert!(!sfz.contains("amp_veltrack")); // 100 = SFZ default, omitted
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- AKP `velocity_sensitivity` range (-100..100) maps **directly** to SFZ `amp_veltrack` — removed incorrect `* 2` scaling
- DecentSampler `ampVelTrack` divides by 100 not 50 — corrected to match ConvertWithMoss
- Both were off by a factor of 2 (default 25 produced 50/0.50 instead of correct 25/0.25)

## Verified against
- ConvertWithMoss source: `AkpOutput.java`, `AkpKeygroup.java`, `SfzCreator.java`, `DecentSamplerCreator.java`
- burnit.co.uk AKP spec (out chunk, offset 0x0029)

## Test plan
- [x] `cargo test` — 53 tests pass
- [x] Tests updated to assert correct values